### PR TITLE
fix(desktopView): Set Z-Index of Fullscreen widgets to highest value. Se...

### DIFF
--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -30,7 +30,7 @@ angular.module('ozpWebtop.constants')
  * @property useIwc
  * @type Boolean
  */
-.constant('useIwc', true)
+.constant('useIwc', false)
 
 /**
  * Number of sticky dashboard slots (for each grid and desktop layouts)

--- a/src/app/dashboardView/chrome/ozpchrome.tpl.html
+++ b/src/app/dashboardView/chrome/ozpchrome.tpl.html
@@ -1,4 +1,4 @@
-<div class="ozp-chrome">
+<div class="ozp-chrome" ng-dblclick="maximizeFrame()">
   <img class="chrome-icon" ng-src="{{frame.icon.small}}">
   <span class="chrome-name">{{frame.name}}</span>
   <span class="chrome-controls" >

--- a/src/app/ozpToolbar/ozpToolbar.js
+++ b/src/app/ozpToolbar/ozpToolbar.js
@@ -145,9 +145,9 @@ app.directive('ozpToolbar', function(){
      scope.$watch('fullScreenMode', function() {
        if (scope.fullScreenMode) {
          // TODO: a cleaner way?
-         $('body').css('padding-top', '16px');
+         $('body').css('padding', '16px 0px');
        } else {
-         $('body').css('padding-top', '57px');
+         $('body').css('padding', '57px 0px');
          $('.navbar-fixed-top').css('top', '16px');
        }
      });

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -19,18 +19,14 @@
 
 
 html {
-  position: relative;
-  min-height: 100%;
+  height: 100%;
+  width: 100%;
   background-color: @dashboard-bg-color;
   // Always show scroll bar - prevents nasty issue with gridster where the
   // screen continuously changes size ~once per second
 //  overflow: -moz-scrollbars-vertical;
 //  overflow-y: scroll;
   //overflow-y: hidden;
-}
-
-body {
-  margin-bottom: @app-toolbar-height;
 }
 
 // bring back vertical dividers in bootstrap 3.0
@@ -184,6 +180,8 @@ input.ng-invalid {
 
 .ui-view-style {
   height: 100%;
+  width: 100%;
+  overflow-y: scroll;
 }
 
 // Grid view
@@ -357,11 +355,14 @@ body > div.classBanner:last-of-type {
   // height of the top and bottom toolbars). Ideally, this would be something
   // like 100vh - (height of top + bottom toolbars). Haven't found anything
   // that works like that yet.
-  height: 100vh;
+  position: fixed;
+  width: 100%;
+  height: 100%;
   overflow-y: hidden;
 }
 
 .grid-view {
+  position: relative;
   overflow-y: auto;
 }
 
@@ -381,6 +382,8 @@ body > div.classBanner:last-of-type {
   left: 0 !important;
   top: @app-toolbar-height + @classification-banner !important;
   bottom: @app-toolbar-height  + @classification-banner !important;
+  position: fixed;
+  z-index: 999999;
 }
 
 .fullWidthTopHidden {


### PR DESCRIPTION
...t desktop view to fixed to prevent scrolling. Added double-click chrome bar to maximize (like windows desktop environments).  Setting useIwc constant to false until it is working again. 

Closes #341 and #343