### PR TITLE
feature(urlWidgetLauncher): Launch widgets into a dashboard via URLs

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -31,6 +31,7 @@
  * @requires ozpWebtop.dashboardView.grid
  * @requires ozpWebtop.addApplicationsModal
  * @requires ozpWebtop.editDashboardModal
+ * @requires ozpWebtop.urlWidgetLauncher
  * @requires ui.router
  * @requires ct.ui.router.extras
  * @requires ui.bootstrap
@@ -64,6 +65,7 @@ angular.module( 'ozpWebtop', [
   'ozpWebtop.dashboardView.grid',
   'ozpWebtop.addApplicationsModal',
   'ozpWebtop.editDashboardModal',
+  'ozpWebtop.urlWidgetLauncher',
   'ui.router',
   'ct.ui.router.extras',
   'ui.bootstrap',
@@ -111,6 +113,9 @@ angular.module( 'ozpWebtop', [
 
       states.push(desktopState);
     }
+
+    states.push({name: 'url-launch-app', url: '/launchApp/:appId',
+      controller: 'UrlWidgetLauncherCtrl'});
 
     angular.forEach(states, function(state) { $stateProvider.state(state); });
     $urlRouterProvider.otherwise('/');

--- a/src/app/urlWidgetLauncher/urlWidgetLauncher.js
+++ b/src/app/urlWidgetLauncher/urlWidgetLauncher.js
@@ -1,0 +1,65 @@
+'use strict';
+
+/**
+ * The url widget launcher launches a new widget in the user's current dashboard
+ * (a new dashboard is created containing this widget if no dashboards for the
+ * user exist). This is a stop gap solution - ultimately, this functionality
+ * needs to be handled via IWC Intents
+ *
+ * @module ozpWebtop.urlWidgetLauncher
+ */
+angular.module('ozpWebtop.urlWidgetLauncher', []);
+
+var app = angular.module( 'ozpWebtop.urlWidgetLauncher');
+/**
+ * Controller for url widget launcher
+ *
+ * ngtype: controller
+ *
+ * @class UrlWidgetLauncherCtrl
+ * @constructor
+ * @param $scope ng $scope
+ * @param $rootScope ng $rootScope
+ * @namespace urlWidgetLauncher
+ *
+ */
+app.controller('UrlWidgetLauncherCtrl',
+  function($scope, $state, dashboardApi) {
+
+    $scope.$on('$stateChangeSuccess',
+      function(event, toState, toParams) {
+        if (toState.name === 'url-launch-app') {
+          console.log('Opening app ' + toParams.appId);
+          // Get user's dashboard data - if it's present, redirect to first
+          // board. If not present, create a default board
+          dashboardApi.getCurrentDashboard().then(function(dashboard) {
+            if (!dashboard) {
+              console.log('No dashboards found, creating a default one');
+              dashboardApi.createInitialDashboardData().then(function() {
+                // now get this dashboard id
+                dashboardApi.getDashboards().then(function(dashboards) {
+                  // we know we only have one dashboard
+                  var dashboardId = dashboards[0].id;
+                  var stickyIndex = dashboards[0].stickyIndex;
+                  // redirect user to new dashboard (grid view by default) after
+                  // adding this app to the board
+                  dashboardApi.createFrame(dashboardId, toParams.appId, 25).then(function() {
+                    console.log('Adding app ' + toParams.appId + ' to default dashboard and redirecting ...');
+                    $state.go('dashboardview.grid-sticky-' + stickyIndex, {
+                      'dashboardId': dashboardId});
+                  });
+                });
+              });
+            } else {
+              // redirect user to this dashboard after adding this app to the board
+              dashboardApi.createFrame(dashboard.id, toParams.appId, 25).then(function() {
+                console.log('Adding app ' + toParams.appId + ' to existing dashboard ' + dashboard.id + ' and redirecting ...');
+                $state.go('dashboardview.' + dashboard.layout + '-sticky-' +
+                  dashboard.stickyIndex, {dashboardId: dashboard.id});
+              });
+            }
+          });
+        }
+    });
+  }
+);

--- a/tools/ozpDataUtility/index.html
+++ b/tools/ozpDataUtility/index.html
@@ -131,6 +131,7 @@
               <th>Small Icon</th>
               <th>Name</th>
               <th>Short Description</th>
+              <th>Id</th>
               <th>Link</th>
             </tr>
           </thead>
@@ -144,6 +145,7 @@
             </td>
             <td>{{app.name}}</td>
             <td>{{app.descriptionShort}}</td>
+            <td>{{app.id}}</td>
             <td><a href="{{app.launchUrls.default}}">Link</a></td>
           </tr>
           </tbody>


### PR DESCRIPTION
Adds a /launchApp/:appId route that will load the given app/widget into the current dashboard (or create a new dashboard with this app if no dashboards exist)

Adds the app UUID to the OZP Data Utility

Closes #394