### PR TITLE
chore(iwc): IWC client will only use the bus configured in OzoneConfig.j...

### DIFF
--- a/src/common/iwcConnectedClient/iwcConnectedClient.js
+++ b/src/common/iwcConnectedClient/iwcConnectedClient.js
@@ -23,17 +23,9 @@ var app = angular.module('ozp.common.iwc.client');
  */
 app.factory('iwcConnectedClient', function($q, $location, $window, iwcClient) {
 
-  var ozpIwcPeerUrl = '';
-  var queryParams = $location.search();
-  if (queryParams.hasOwnProperty('ozpIwc.peer')) {
-    ozpIwcPeerUrl = queryParams['ozpIwc.peer'];
-  } else {
-    ozpIwcPeerUrl = $window.OzoneConfig.IWC_URL;
-  }
-
-  console.log('creating iwc client using bus: ' + ozpIwcPeerUrl);
+  console.log('creating iwc client using bus: ' + $window.OzoneConfig.IWC_URL);
   var client = new iwcClient.Client({
-    peerUrl: ozpIwcPeerUrl
+    peerUrl: $window.OzoneConfig.IWC_URL
   });
 
   var isConnected = false;
@@ -64,7 +56,7 @@ app.factory('iwcConnectedClient', function($q, $location, $window, iwcClient) {
       return deferred.promise;
       },
     getIwcBusUrl: function() {
-      return ozpIwcPeerUrl;
+      return $window.OzoneConfig.IWC_URL;
     }
   };
 });


### PR DESCRIPTION
...s

The ability to use a custom IWC bus via the ozpIwc.peer query parameter was in a broken state. It has been removed entirely until/if it is ever deemed necessary

Closes #393