### PR TITLE
fix(desktopLayout): fixes IE desktop layout bug

### DIFF
--- a/src/app/dashboardView/desktop/desktop.js
+++ b/src/app/dashboardView/desktop/desktop.js
@@ -201,6 +201,13 @@ angular.module('ozpWebtop.dashboardView.desktop')
               $scope.frames[jj].desktopLayout.left = updatedDashboard.frames[ii].desktopLayout.left;
               $scope.frames[jj].desktopLayout.width = updatedDashboard.frames[ii].desktopLayout.width;
               $scope.frames[jj].desktopLayout.height = updatedDashboard.frames[ii].desktopLayout.height;
+              $scope.frames[jj].desktopLayout.style = {
+                width: $scope.frames[jj].desktopLayout.width + 'px',
+                height: $scope.frames[jj].desktopLayout.height + 'px',
+                top: $scope.frames[jj].desktopLayout.top + 'px',
+                left: $scope.frames[jj].desktopLayout.left + 'px',
+                'z-index': $scope.frames[jj].desktopLayout.zIndex
+              };
             }
           }
         }
@@ -251,8 +258,6 @@ angular.module('ozpWebtop.dashboardView.desktop')
      * @method reloadDashboard
      */
     function reloadDashboard() {
-      // app information is retrieved asynchronously from IWC. If the
-      // information isn't available yet, try again later
       if (!$scope.ready) {
         $log.warn('DesktopCtrl: delaying call to reloadDashboard by 500ms - no data yet');
         $scope.reloadDashboardInterval = $interval(function() {

--- a/src/app/dashboardView/desktop/desktop.tpl.html
+++ b/src/app/dashboardView/desktop/desktop.tpl.html
@@ -2,10 +2,7 @@
 <div ng-repeat="frame in frames">
   <ozp-managed-frame myframe="frame" class="ozp-managed-frame"
                      ng-hide="isFrameMinimized(frame)"
-                     style="width: {{frame.desktopLayout.width}}px;
-                     height: {{frame.desktopLayout.height}}px;
-                     top: {{frame.desktopLayout.top}}px;
-                     left: {{frame.desktopLayout.left}}px"
+                     ng-style="frame.desktopLayout.style"
                      ng-class="{'fullWidth' : frame.isMaximized}">
   </ozp-managed-frame>
 </div>


### PR DESCRIPTION
Fixes bug where widget positions are not respected in IE. This caused
widget locations to reset on top of each other as well as the cascade
button to break

Closes #449