### PR TITLE
fix(*): Handle frames with no matching application data

### DIFF
--- a/src/app/models/dashboardApi.js
+++ b/src/app/models/dashboardApi.js
@@ -538,10 +538,12 @@ function generalDashboardModel($sce, $q, $log, $http, $window, persistStrategy, 
      */
     mergeApplicationData: function(frames) {
       var marketplaceApps = this._applicationData;
-      for (var i=0; i < marketplaceApps.length; i++) {
-        // check if this app is on our dashboard
-        for (var j=0; j < frames.length; j++) {
+
+      for (var j=0; j < frames.length; j++) {
+        var foundApp = false;
+        for (var i=0; i < marketplaceApps.length; i++) {
           if (frames[j].appId === marketplaceApps[i].id) {
+            foundApp = true;
             // if it is, then get all relevant info
             frames[j].icon = {};
             frames[j].icon.small = marketplaceApps[i].icons.small;
@@ -554,7 +556,14 @@ function generalDashboardModel($sce, $q, $log, $http, $window, persistStrategy, 
             frames[j].descriptionShort = marketplaceApps[i].descriptionShort;
             // TODO: get this data for real
             frames[j].singleton = false;
+            break;
           }
+        }
+        if (!foundApp) {
+          $log.warn('Found a frame with no corresponding application');
+          frames[j].trustedUrl = 'assets/appNotFound/index.html';
+          frames[j].name = 'Not Found';
+          frames[j].singleton = false;
         }
       }
     },

--- a/src/assets/appNotFound/index.html
+++ b/src/assets/appNotFound/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
+</head>
+
+<body style="background-color: white;">
+    <h1 style="color: red;">Application not found</h1>
+    <p>
+        This usually happens when you un-bookmark an application from Center that
+        was already in one of your dashboards. Please visit Center and ensure that
+        this application is bookmarked.
+    </p>
+</body>
+</html>


### PR DESCRIPTION
If a user un-bookmarks an application from Center or HUD that they
already have in a dashboard, the applications frame will be empty (the
so-called "phantom widget" problem). Now they will at least get an error
message, though it will not contain the name of the application that is
missing

Closes #411