### PR TITLE
fix(*): Closing widgets should be set to about:blank before removing to trigger their unload

### DIFF
--- a/src/app/appToolbar/appToolbar.js
+++ b/src/app/appToolbar/appToolbar.js
@@ -17,7 +17,8 @@ angular.module('ozpWebtop.appToolbar', ['ui.router', 'ui.bootstrap',
   'ozpWebtop.models.userSettings',
   'ozpWebtop.addApplicationsModal',
   'ozpWebtop.editDashboardModal',
-  'ozp.common.windowSizeWatcher']);
+  'ozp.common.windowSizeWatcher',
+  'ozpWebtop.dashboardView.grid']);
 
 /**
  * Application toolbar on the bottom of Webtop. Contains a menu for adding
@@ -60,7 +61,8 @@ angular.module( 'ozpWebtop.appToolbar')
                                                  dashboardStateChangedEvent,
                                                  fullScreenModeToggleEvent,
                                                  highlightFrameOnGridLayoutEvent,
-                                                 initialDataReceivedEvent) {
+                                                 initialDataReceivedEvent,
+                                                 removeFramesOnDeleteEvent) {
 
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -639,6 +641,8 @@ angular.module( 'ozpWebtop.appToolbar')
       var msg = 'Are you sure you want to delete dashboard ' +
           board.name + '? This action cannot be undone';
       if ($window.confirm(msg)) {
+        // Notify the grid controller to remove its widgets.
+        $rootScope.$broadcast(removeFramesOnDeleteEvent, {'dashboardId': board.id});
         dashboardApi.removeDashboard(board.id).then(function() {
           // redirect user to their first board
           dashboardApi.getDashboards().then(function(dashboards) {

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -77,6 +77,14 @@ angular.module('ozpWebtop.constants')
 .constant('highlightFrameOnGridLayoutEvent', 'highlightFrameOnGridLayout')
 
 /**
+ * Event fired when a dashboard is closed to remove its frames.
+ * @property removeFrameOnDeleteEvent
+ * @type String
+ */
+.constant('removeFramesOnDeleteEvent', 'removeFramesOnDelete')
+
+
+/**
  * Event fired when app and dashboard data is initially retrieved
  * @property initialDataReceived
  * @type String

--- a/src/app/constants.spec.js
+++ b/src/app/constants.spec.js
@@ -6,13 +6,14 @@ describe('constants', function () {
 
   var useIwc, deviceSizeChangedEvent, windowSizeChangedEvent,
     dashboardStateChangedEvent,
-    fullScreenModeToggleEvent, highlightFrameOnGridLayoutEvent;
+    fullScreenModeToggleEvent, highlightFrameOnGridLayoutEvent, removeFramesOnDeleteEvent;
 
   beforeEach(inject(function (_useIwc_, _deviceSizeChangedEvent_,
                               _windowSizeChangedEvent_,
                               _dashboardStateChangedEvent_,
                               _fullScreenModeToggleEvent_,
-                              _highlightFrameOnGridLayoutEvent_
+                              _highlightFrameOnGridLayoutEvent_,
+                              _removeFramesOnDeleteEvent_
     ) {
     useIwc = _useIwc_;
     deviceSizeChangedEvent = _deviceSizeChangedEvent_;
@@ -20,6 +21,7 @@ describe('constants', function () {
     dashboardStateChangedEvent = _dashboardStateChangedEvent_;
     fullScreenModeToggleEvent = _fullScreenModeToggleEvent_;
     highlightFrameOnGridLayoutEvent = _highlightFrameOnGridLayoutEvent_;
+    removeFramesOnDeleteEvent = _removeFramesOnDeleteEvent_;
 
   }));
 


### PR DESCRIPTION
The webtop widget frames do not trigger the unload event on the frame when it is closed. Setting its source to `about:blank` and moving the removal to the end of the event loop will give the iframe the ability to handle its unload and then remove the frame.