### PR TITLE
chore(bower): remove moot `version` property

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -96,8 +96,7 @@ module.exports = function ( grunt ) {
     bump: {
       options: {
         files: [
-          'package.json',
-          'bower.json'
+          'package.json'
         ],
         commit: true,
         commitMessage: 'chore(release): v%VERSION%',

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "ozpwebtop",
-  "version": "0.4.16",
   "devDependencies": {
     "angular-mocks": "~1.4.1",
     "es5-shim": "~4.1.0",


### PR DESCRIPTION
Per the [Bower spec](https://github.com/bower/bower.json-spec#version) the version property is not used for anything.  

One of the maintainers also says that they are [not likely to use it in the future](http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property).

Also went ahead and removed the relevant grunt-bump config.