### PR TITLE
IWC Angular Lib Repo change

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
     "angular-gridster": "~0.9.11",
     "jquery-ui": "~1.11.0",
     "console-polyfill": "latest",
-    "ozp-iwc-angular": "ozone-development/ozp-iwc-angular#master",
+    "ozp-iwc": "ozone-development/ozp-iwc",
     "ozp-classification": "ozone-development/ozp-classification",
     "bootstrap": "ozone-development/bootstrap#18f02afee202d63699b8782ec0c737860e14b885",
     "ubuntu-fontface": "~0.1.3",

--- a/build.config.js
+++ b/build.config.js
@@ -80,7 +80,7 @@ module.exports = {
       'vendor/angular-ui-utils/modules/route/route.js',
       'vendor/angular-gridster/dist/angular-gridster.min.js',
       'vendor/javascript-detect-element-resize/detect-element-resize.js',
-      'vendor/ozp-iwc-angular/dist/js/ozpIwc-client-angular.js',
+      'vendor/ozp-iwc/dist/js/ozpIwc-client-angular.js',
       'vendor/es6-promise/promise.min.js',  // Promises not enabled by default in FF until v29.0
       'vendor/console-polyfill/index.js',
       'vendor/ozp-classification/jquery.classification.js',

--- a/src/common/iwcConnectedClient/iwcConnectedClient.js
+++ b/src/common/iwcConnectedClient/iwcConnectedClient.js
@@ -18,7 +18,7 @@ var app = angular.module('ozp.common.iwc.client');
  * @class iwcConnectedClient
  * @constructor
  * @param $q ng $q service
- * @param iwcClient iwcClient service from ozp-iwc-angular library
+ * @param iwcClient iwcClient service from ozp-iwc library
  * @namespace ozp.common.iwc
  */
 app.factory('iwcConnectedClient', function($q, $location, $window, $log, iwcClient) {


### PR DESCRIPTION
feat(iwc): Moved to ozp-iwc hosted angular libs.

ozp-iwc-angular is now deprecated. Update webtop to gather the angular libs from ozp-iwc.