### PR TITLE
IWC intent choosing & updated ozp interface

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -29,6 +29,7 @@
  * @requires ozpWebtop.createDashboardModal
  * @requires ozpWebtop.appWarningModal
  * @requires ozpWebtop.profileModal
+ * @requires ozpWebtop.iwcIntentModal
  * @requires ozpWebtop.settingsModal
  * @requires ozpWebtop.helpModal
  * @requires ozpWebtop.urlWidgetLauncher
@@ -48,8 +49,7 @@ angular.module( 'ozpWebtop', [
   'templates-app',
   'templates-common',
   'ozpWebtop.constants',
-  'ozpWebtop.services.iwcInterface',
-  'ozpWebtop.services.restInterface',
+  'ozpWebtop.services.ozpInterface',
   'ozpWebtop.models',
   'ozpWebtop.appToolbar',
   'ozpWebtop.ozpToolbar',
@@ -61,6 +61,7 @@ angular.module( 'ozpWebtop', [
   'ozpWebtop.dashboardView.grid',
   'ozpWebtop.addApplicationsModal',
   'ozpWebtop.profileModal',
+  'ozpWebtop.iwcIntentModal',
   'ozpWebtop.settingsModal',
   'ozpWebtop.helpModal',
   'ozpWebtop.editDashboardModal',
@@ -141,7 +142,7 @@ angular.module( 'ozpWebtop', [
   })
 
 .run( function run ($rootScope, $state, $http, $window, $log,
-                    models, restInterface, useIwc, initialDataReceivedEvent, notificationReceivedEvent) {
+                    models, ozpInterface, initialDataReceivedEvent, notificationReceivedEvent) {
 
     $rootScope.$state = $state;
 
@@ -153,9 +154,9 @@ angular.module( 'ozpWebtop', [
       the only time we will go to the server (and wait for a response) for
       Listing data and/or webtop data
      */
-    restInterface.getListings().then(function(listings) {
-      models.setApplicationData(listings);
-      restInterface.getWebtopData().then(function(webtopData) {
+      ozpInterface.getListings().then(function(listings) {
+        models.setApplicationData(listings);
+        ozpInterface.getWebtopData().then(function(webtopData) {
         if (webtopData) {
           models.setInitialWebtopData(webtopData);
           $log.info('application listings and dashboard data retrieved - ready to start');
@@ -170,7 +171,7 @@ angular.module( 'ozpWebtop', [
       // Get the notifications on load.
       // TODO when there is a way to communicate changes from the server to the
       //      application show notification updates live
-      restInterface.getNotifications().then(function(notifications) {
+      ozpInterface.getNotifications().then(function(notifications) {
         $rootScope.$broadcast(notificationReceivedEvent, notifications);
       });
     });

--- a/src/app/services/ozpInterface.js
+++ b/src/app/services/ozpInterface.js
@@ -1,0 +1,35 @@
+'use strict';
+
+/**
+ * Interface for working with the ozp-rest API
+ *
+ * @module ozpWebtop.services.ozpInterface
+ */
+angular.module('ozpWebtop.services.ozpInterface', []);
+
+var app = angular.module('ozpWebtop.services.ozpInterface',[
+    'ozpWebtop.services.iwcInterface',
+    'ozpWebtop.services.restInterface']);
+
+/**
+ * Interface for working with ozp-rest will return IWC interface if useIwc constant is true.
+ * Otherwise will return the rest interface
+ *
+ * ngtype: factory
+ *
+ * @class ozpInterface
+ * @constructor
+ * @param iwcInterface IWC ozp-rest interface
+ * @param restInterface REST ozp-rest interface
+ * @param useIwc webtop constant
+ * @namespace services
+ */
+app.factory('ozpInterface', function(iwcInterface, restInterface, useIwc) {
+    var intrface =  (useIwc) ? iwcInterface : restInterface;
+
+    //TODO remove force to rest functionality once implemented on IWC
+    intrface.getUserListings = restInterface.getUserListings;
+    intrface.getNotifications = restInterface.getNotifications;
+
+    return intrface;
+});

--- a/src/app/userInterface/iwcIntentModal/iwcIntentModal.controller.js
+++ b/src/app/userInterface/iwcIntentModal/iwcIntentModal.controller.js
@@ -1,0 +1,130 @@
+'use strict';
+
+angular.module('ozpWebtop.iwcIntentModal', ['ui.bootstrap', 'ozpWebtop.models']);
+/**
+* Controller for IWC Intent Chooser modal
+*
+* @param $scope
+* @param $modalInstance
+* @param $restInterface
+* @constructor
+*/
+angular.module('ozpWebtop.iwcIntentModal').controller(
+  'iwcIntentModalInstanceCtrl', function($scope, $window, $modalInstance,$log, client,inFlightIntent) {
+    inFlightIntent = inFlightIntent || {};
+    inFlightIntent.entity = inFlightIntent.entity || {};
+    inFlightIntent.entity.intent = inFlightIntent.entity.intent || {};
+
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    //                            $scope properties
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    $scope.handlerChoices = inFlightIntent.entity.handlerChoices || [];
+    $scope.type = inFlightIntent.entity.intent.type;
+    $scope.action = inFlightIntent.entity.intent.action;
+
+
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    //                          methods
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    /**
+     * Sends IWC intent payload data for an intent handler selection.
+     *
+     * @method respondSelected
+     * @param payload the data to send to the IWC intents.api
+     * @returns {Promise}
+     */
+    function respondSelected (payload){
+      return client.intents().set(inFlightIntent.resource,payload).catch(function(err){
+        $log.error('Unexpected error on IWC intent choosing: ', err);
+        $modalInstance.dismiss('cancel');
+      });
+    }
+
+    /**
+    * Handler invoked when an application is clicked
+    *
+    * @method choiceSelected
+    * @param handler application selected
+    */
+    $scope.handlerSelected = function(handler) {
+      $scope.selectedHandler = handler.resource;
+    };
+
+    /**
+    * Returns true if the given handler is selected, false
+    * otherwise
+    *
+    * @method isAppSelected
+    * @param app the application to check
+    * @returns {boolean}
+    */
+    $scope.isHandlerSelected = function(handler) {
+      return $scope.selectedHandler === handler.resource;
+    };
+
+    /**
+     * Sends IWC response to always use the selected handling application.
+     * @method useHandlerAlways
+     */
+    $scope.useHandlerAlways = function(){
+      //TODO: update handler payload to set the preference. Currently just behaves like $scope.useHandler
+      var handlerPayload = {
+        contentType: inFlightIntent.entity.contentType,
+        entity: {
+          'state': 'delivering',
+          'handler' : {
+            'resource':$scope.selectedHandler,
+            'reason': 'userSelected'
+          }
+        }
+      };
+
+      respondSelected(handlerPayload).then(function(){
+          $modalInstance.close();
+      });
+    };
+
+    /**
+     * Sends IWC response to use the selected handling application. This choice does not persist.
+     * @method useHandler
+     */
+    $scope.useHandler = function(){
+      var handlerPayload = {
+        contentType: inFlightIntent.entity.contentType,
+        entity: {
+          'state': 'delivering',
+          'handler' : {
+            'resource':$scope.selectedHandler,
+            'reason': 'userSelected'
+          }
+        }
+      };
+
+      respondSelected(handlerPayload).then(function(){
+        $modalInstance.close();
+      });
+    };
+
+    /**
+     * Handler invoked when modal is dismissed via the cancel button
+     *
+     * @method cancel
+     */
+    $scope.cancel = function () {
+      var userCanceledPayload = {
+        contentType: inFlightIntent.contentType,
+        entity: {
+          reply: {
+            contentType: inFlightIntent.contentType,
+            entity: 'User canceled the selection.'
+          },
+          state: 'complete'
+        }
+      };
+
+      client.intents().set(inFlightIntent.resource, userCanceledPayload);
+      $modalInstance.dismiss('cancel');
+    };
+
+});

--- a/src/app/userInterface/iwcIntentModal/iwcIntentModal.tpl.html
+++ b/src/app/userInterface/iwcIntentModal/iwcIntentModal.tpl.html
@@ -1,0 +1,48 @@
+<div class="wt-modal add-apps-style" id="modal_openApps">
+  <div class="modal-header wt-modal-header">
+    <button type="button" class="close" ng-click="cancel()">
+      <span aria-hidden="true"><i class="icon-cross-14-grayLightest"></i> </span>
+      <span class="sr-only">Close</span>
+    </button>
+    <h3 class="modal-title">Intent Chooser</h3>
+      <div class="container-fluid">
+        <div class="row">
+          <div class="col-md-12">
+            <span tooltip-placement="right" tooltip="TODO">
+              Intent Type: {{type}}
+            </span>
+          </div>
+          <div class="col-md-12">
+            <span tooltip-placement="right" tooltip="TODO">
+              Intent Action: {{action}}
+            </span>
+          </div>
+        </div>
+      </div>
+  </div>
+  <div class="modal-body wt-modal-body">
+    <div class="container-fluid">
+      <div class="row">
+        <div class="col-md-12 add-apps-list">
+          <ul id="triple">
+            <li ng-repeat="handler in handlerChoices">
+              <span ng-click="handlerSelected(handler)" class="link-pointer"
+                  ng-class="{addappselected: isHandlerSelected(handler)}">
+                <img ng-src="{{handler.entity.icon}}" height="20" width="20" />
+                {{handler.entity.label}}
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="modal-footer wt-modal-footer">
+    <button class="btn btn-default" ng-disabled="!selectedHandler" ng-click="useHandlerAlways()">
+      Use Always
+    </button>
+    <button class="btn btn-primary" ng-disabled="!selectedHandler" ng-click="useHandler()">
+      Use once
+    </button>
+  </div>
+</div>

--- a/src/app/userInterface/ozpToolbar/ozpToolbar.controller.js
+++ b/src/app/userInterface/ozpToolbar/ozpToolbar.controller.js
@@ -12,7 +12,7 @@ angular.module('ozpWebtop.ozpToolbar', [
   'ozpWebtop.models',
   'ozpWebtop.settingsModal',
   'ozpWebtop.filters',
-  'ozpWebtop.services.restInterface']);
+  'ozpWebtop.services.ozpInterface']);
 
 angular.module( 'ozpWebtop.ozpToolbar')
 /**
@@ -32,13 +32,14 @@ angular.module( 'ozpWebtop.ozpToolbar')
  * @param windowSizeWatcher notify when window size changes
  * @param deviceSizeChangedEvent event name
  * @param fullScreenModeToggleEvent event name
+ * @param ozpInterface module for backend communication
  * @namespace ozpToolbar
  *
  */
 .controller('OzpToolbarCtrl',
   function($scope, $rootScope, $window, $log, $modal,
            models, windowSizeWatcher, deviceSizeChangedEvent, tooltipDelay,
-           fullScreenModeToggleEvent, restInterface, notificationReceivedEvent) {
+           fullScreenModeToggleEvent, ozpInterface, notificationReceivedEvent) {
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     //                            $scope properties
@@ -256,7 +257,7 @@ angular.module( 'ozpWebtop.ozpToolbar')
       * @property isAdmin indicates if the user is an admin
       * @property isOrgSteward indicates if the user is an org steward
       */
-     restInterface.getProfile().then(function(d){
+    ozpInterface.getProfile().then(function(d){
        var userRole=d.highestRole;
        if(userRole === 'ADMIN'){
           $scope.isAdmin = true;

--- a/src/app/userInterface/profileModal/profileModal.controller.js
+++ b/src/app/userInterface/profileModal/profileModal.controller.js
@@ -1,23 +1,21 @@
 'use strict';
 
 angular.module('ozpWebtop.profileModal', ['ui.bootstrap',
-'ozpWebtop.models','ozpWebtop.services.restInterface']);
+'ozpWebtop.models','ozpWebtop.services.ozpInterface']);
 /**
 * Controller for profile modal
 *
 * @param $scope
 * @param $modalInstance
-* @param $restInterface
+* @param ozpInterface interface for backend communication
 * @constructor
 */
 angular.module('ozpWebtop.profileModal').controller(
-'profileModalInstanceCtrl', function($scope, $window, $modalInstance, restInterface) {
-
+'profileModalInstanceCtrl', function($scope, $window, $modalInstance, ozpInterface) {
 
 	// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     //                           initialization
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
 	$scope.centerUrl = $window.OzoneConfig.CENTER_URL;
 
 
@@ -29,7 +27,8 @@ angular.module('ozpWebtop.profileModal').controller(
 	* Gets user profile data
 	*
 	*/
-	restInterface.getProfile().then(function(data){
+
+	ozpInterface.getProfile().then(function(data){
 		var getProfile = data;
 
 		$scope.profileName = getProfile.displayName;
@@ -37,11 +36,10 @@ angular.module('ozpWebtop.profileModal').controller(
 		$scope.profileEmail = getProfile.email;
 	});
 
-/**
+	/**
 	* Gets user listing data
-	*
 	*/
-	restInterface.getUserListings().then(function(data){
+	ozpInterface.getUserListings().then(function(data){
 		  $scope.getUserListings = data._embedded.item;
 
 		 $scope.listingImg = data.imageMediumUrl;


### PR DESCRIPTION
feat(ozpInterface): Added interface variable for IWC integration.
feat(ozpInterface): Added intent chooser modal and registration.
feat(iwcConnectedClient): Cleaned up intent chooser modal registration.
feat(ozpInterface): added wrapper interface around iwc/rest interfaces.
feat(ozpInterface): force to rest for notifications.

Added intent chooser built into webtop as a modal to handle user intent choosing. If multiple webtops are open the webtop in focus will open the chooser. If all webtops are out of focus and an intent choosing needs to occur (webtop minimized) the default IWC intent chooser is opened as a popup window. (IWC will handle IE11, if IE11 is used and this behavior occurs the intent chooser will still open on the webtop due to IE11 limitations)

refs #617 