### PR TITLE
fix(addAppModal):update the addWidgets modal when launching a folder. #633

### DIFF
--- a/src/app/userInterface/appToolbar/appToolbar.controller.js
+++ b/src/app/userInterface/appToolbar/appToolbar.controller.js
@@ -184,6 +184,7 @@ angular.module( 'ozpWebtop.appToolbar')
         } else {
           return;
         }
+        initializeData();
         $scope.handleStateChange(toParams.dashboardId, layoutType);
     });
 


### PR DESCRIPTION
To test, launch a folder in webtop. Click the blue box with the plus in the lower left of webtop to launch add applications modal, verify the items you launched are in your applications list.