### PR TITLE
chore(package.json): Support npm v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "bower": "^1.3.12",
+    "coffeelint": "^1",
     "grunt": "~0.4.1",
     "grunt-bump": "0.0.6",
     "grunt-cli": "^0.1.13",


### PR DESCRIPTION
Closes #660

Had to make the fix as described here: https://github.com/vojtajina/grunt-coffeelint/issues/66